### PR TITLE
Add author pages

### DIFF
--- a/src/pybucketgames/generate.py
+++ b/src/pybucketgames/generate.py
@@ -187,7 +187,11 @@ class Page:
                 if not pathlib.Path(os.path.dirname(destination)).is_dir():
                     os.makedirs(os.path.dirname(destination), exist_ok=True)
                     print("Warning: Unexpected directory",os.path.dirname(destination), "created when linking image", file_path, ". This can expose undesired files.")
-                shutil.copy(file_path, destination)
+                
+                try:
+                    shutil.copy(file_path, destination)
+                except shutil.SameFileError:
+                    print("Warning: Tried to copy "+str(file_path)+" to "+str(destination)+" which is the same file")
                 linked.add(destination)
 
             return filename
@@ -347,6 +351,42 @@ def apply_template(destination: pathlib.Path, template: str, game_path: pathlib.
 
     destination.write_text(rendered, encoding="utf-8")
 
+def generate_author_page(author_name: str, author_games: list[Game], bucket_path: pathlib.Path, website: pathlib.Path, bucket_toml: dict):
+    author_name_path = get_author_path(author_name)
+
+    author_toml = bucket_toml.copy()
+    
+    author_toml_path = bucket_path / 'authors' / (author_name_path + ".toml")
+    if author_toml_path.is_file():
+        try:
+            with open(author_toml_path, "rb") as f:
+                author_toml.update(tomllib.load(f))
+        except tomllib.TOMLDecodeError as e:
+            raise SystemExit(f"Error trying to open author file {author_toml_path}: {e}")
+
+    if 'author_pic' in author_toml:
+        auth_pic_path = pathlib.Path(author_toml['author_pic'])
+        auth_pic_path = pathlib.Path('authors') / auth_pic_path
+        author_toml['author_pic'] = str(auth_pic_path)
+
+    author_bucket_object = Bucket(
+        path=bucket_path,
+        website_path=website,
+        games=author_games,
+        toml=author_toml,
+    )
+
+    proxy = author_bucket_object.proxy()
+
+    (website / "author" / author_name_path).mkdir(exist_ok=True, parents=True)
+    apply_template(
+        destination=website / "author" / author_name_path / 'index.html',
+        template="author.html",
+        game_path=bucket_path,
+        bucket=proxy,
+        page=proxy,
+    )
+
 def scan_release(game_path: pathlib.Path, release_path: pathlib.Path) -> Release:
     """
     Scans a release directory and returns a Release object.
@@ -441,14 +481,33 @@ def generate_game(game_path: pathlib.Path, website_path: pathlib.Path) -> Game:
     except tomllib.TOMLDecodeError as e:
         raise SystemExit(f"Error decoding {game_toml_path}: {e}")
 
+    # Check if deprecation notice should be displayed for author_toml location
+    if "author" in game_toml and "author_file" in game_toml:
+        author_name_path = get_author_path(game_toml["author"])
+        correct_author_toml_path = game_path / '..' / 'authors' / (author_name_path + ".toml")
+        if not game_toml["author_file"] == (author_name_path + ".toml"):
+            print("Deprecated:", game_toml["author_file"], "should be moved to", correct_author_toml_path)
+
     # Allow importing [author].toml in [bucket]/authors with author_file for reusable author info
+    author_toml = {}
     if "author_file" in game_toml:
         author_toml_path = game_path / '..' / 'authors' / game_toml["author_file"]
         try:
             with open(author_toml_path, "rb") as f:
-                game_toml.update(tomllib.load(f))
+                author_toml = tomllib.load(f)
         except tomllib.TOMLDecodeError as e:
             raise SystemExit(f"Error trying to open author file {author_toml_path}: {e}")
+
+    # Set relative author image path
+    if 'author_pic' in author_toml:
+        if '../' in author_toml['author_pic']:
+            print("Warning: Author image '"+author_toml['author_pic']+"' uses a deprecated path. Consider updating it to be relative to the toml file.")
+
+        auth_pic_path = pathlib.Path(author_toml['author_pic'])
+        auth_pic_path = pathlib.Path('../authors' ) / auth_pic_path
+        author_toml['author_pic'] = str(auth_pic_path)
+
+    game_toml.update(author_toml)
 
     game_toml.setdefault("image_extensions", DEFAULT_IMAGE_EXTENSIONS)
 
@@ -475,6 +534,12 @@ def generate_game(game_path: pathlib.Path, website_path: pathlib.Path) -> Game:
         shutil.copytree(d, website_path / d.name)
 
     releases.sort(key=lambda r: r.date, reverse=True)
+
+    # Default author page
+
+    if "author_link" not in game_toml and "author" in game_toml:
+        author_path = get_author_path(game_toml["author"])
+        game_toml["author_link"] = "author/"+author_path+"/index.html" 
 
     # Title.
 
@@ -655,6 +720,11 @@ def generate(bucket: str) -> None:
 
     games.sort(key=lambda g: g.date, reverse=True)
 
+    games_by_author: dict[str, list[Game]] = {}
+    for game in games:
+        if "author" in game.toml:
+            games_by_author.setdefault(game.toml["author"],[]).append(game)
+
     # Render bucket templates
 
     bucket_object = Bucket(
@@ -688,7 +758,14 @@ def generate(bucket: str) -> None:
         page=proxy,
     )
 
+    # Render author templates
+    for author, author_games in games_by_author.items():
+        generate_author_page(author, author_games, bucket_path, website, bucket_toml)
+
     if "enable_rss" in bucket_object.toml and bucket_object.toml["enable_rss"]:
         generate_rss(games, bucket_object, website)
 
     print("Website files generated successfully.")
+
+def get_author_path(author: str)-> str:
+    return author.lower().replace(" ", "_")

--- a/src/pybucketgames/generate.py
+++ b/src/pybucketgames/generate.py
@@ -482,16 +482,21 @@ def generate_game(game_path: pathlib.Path, website_path: pathlib.Path) -> Game:
         raise SystemExit(f"Error decoding {game_toml_path}: {e}")
 
     # Check if deprecation notice should be displayed for author_toml location
-    if "author" in game_toml and "author_file" in game_toml:
-        author_name_path = get_author_path(game_toml["author"])
-        correct_author_toml_path = game_path / '..' / 'authors' / (author_name_path + ".toml")
-        if not game_toml["author_file"] == (author_name_path + ".toml"):
-            print("Deprecated:", game_toml["author_file"], "should be moved to", correct_author_toml_path)
+    author_toml_path = ""
+    if "author" in game_toml:
+        author_toml_path = bucket_path / 'authors' / (get_author_path(game_toml["author"], False) + ".toml")
+        correct_author_toml_path = author_toml_path
+        if not correct_author_toml_path.is_file():
+            if "author_file" in game_toml:
+                author_toml_path = game_path / '..' / 'authors' / game_toml["author_file"]
+                print("Deprecated:", game_toml["author_file"], "should be moved to", correct_author_toml_path)
+    elif "author_file" in game_toml:
+        author_toml_path = game_path / '..' / 'authors' / game_toml["author_file"]
+        print("Deprecated:", game_path / "game.toml", "has an author_file specified but no author. It's preferred to specify the author name and create the author file at authors/[author_name].toml")
 
     # Allow importing [author].toml in [bucket]/authors with author_file for reusable author info
     author_toml = {}
-    if "author_file" in game_toml:
-        author_toml_path = game_path / '..' / 'authors' / game_toml["author_file"]
+    if author_toml_path and author_toml_path.is_file():
         try:
             with open(author_toml_path, "rb") as f:
                 author_toml = tomllib.load(f)
@@ -501,7 +506,7 @@ def generate_game(game_path: pathlib.Path, website_path: pathlib.Path) -> Game:
     # Set relative author image path
     if 'author_pic' in author_toml:
         if '../' in author_toml['author_pic']:
-            print("Warning: Author image '"+author_toml['author_pic']+"' uses a deprecated path. Consider updating it to be relative to the toml file.")
+            print("Deprecated: Author image '"+author_toml['author_pic']+"' uses a deprecated path. Consider updating it to be relative to the toml file.")
 
         auth_pic_path = pathlib.Path(author_toml['author_pic'])
         auth_pic_path = pathlib.Path('../authors' ) / auth_pic_path
@@ -705,7 +710,7 @@ def generate(bucket: str) -> None:
     bucket_toml.setdefault("image_extensions", DEFAULT_IMAGE_EXTENSIONS)
 
     if "base_url" not in bucket_toml:
-        raise Exception("base_url is required in bucket.toml to generate RSS")
+        raise Exception("base_url is required in bucket.toml")
     base_url = bucket_toml["base_url"]
 
     # Games.

--- a/src/pybucketgames/generate.py
+++ b/src/pybucketgames/generate.py
@@ -540,11 +540,15 @@ def generate_game(game_path: pathlib.Path, website_path: pathlib.Path) -> Game:
 
     releases.sort(key=lambda r: r.date, reverse=True)
 
-    # Default author page
+    # Author page
 
-    if "author_link" not in game_toml and "author" in game_toml:
+    author_page_link: None | pathlib.Path = None
+    if "author" in game_toml:
         author_path = get_author_path(game_toml["author"], True)
-        game_toml["author_link"] = base_url+"author/"+author_path+"/index.html" 
+        author_page_link = pathlib.Path("author") / author_path / "index.html" 
+        # Use as default author link
+        if "author_link" not in game_toml:
+            game_toml["author_link"] = str(author_page_link)
 
     # Title.
 
@@ -604,6 +608,7 @@ def generate_game(game_path: pathlib.Path, website_path: pathlib.Path) -> Game:
         game=proxy,
         page=proxy,
         game_path_web=game_path_web,
+        author_page_link=author_page_link,
     )
 
     apply_template(

--- a/src/pybucketgames/generate.py
+++ b/src/pybucketgames/generate.py
@@ -778,4 +778,5 @@ def generate(bucket: str) -> None:
     print("Website files generated successfully.")
 
 def get_author_path(author: str, is_url = False)-> str:
-    return author.lower().replace(" ", "-" if is_url else "_")
+    replace_char: str = "-" if is_url else "_"
+    return author.lower().replace(" ", replace_char).replace("/", replace_char).replace("?", replace_char)

--- a/src/pybucketgames/generate.py
+++ b/src/pybucketgames/generate.py
@@ -539,7 +539,7 @@ def generate_game(game_path: pathlib.Path, website_path: pathlib.Path) -> Game:
 
     if "author_link" not in game_toml and "author" in game_toml:
         author_path = get_author_path(game_toml["author"])
-        game_toml["author_link"] = "author/"+author_path+"/index.html" 
+        game_toml["author_link"] = base_url+"author/"+author_path+"/index.html" 
 
     # Title.
 

--- a/src/pybucketgames/generate.py
+++ b/src/pybucketgames/generate.py
@@ -352,11 +352,11 @@ def apply_template(destination: pathlib.Path, template: str, game_path: pathlib.
     destination.write_text(rendered, encoding="utf-8")
 
 def generate_author_page(author_name: str, author_games: list[Game], bucket_path: pathlib.Path, website: pathlib.Path, bucket_toml: dict):
-    author_name_path = get_author_path(author_name)
+    author_name_uri_path = get_author_path(author_name, True)
 
     author_toml = bucket_toml.copy()
     
-    author_toml_path = bucket_path / 'authors' / (author_name_path + ".toml")
+    author_toml_path = bucket_path / 'authors' / (get_author_path(author_name, False) + ".toml")
     if author_toml_path.is_file():
         try:
             with open(author_toml_path, "rb") as f:
@@ -378,9 +378,9 @@ def generate_author_page(author_name: str, author_games: list[Game], bucket_path
 
     proxy = author_bucket_object.proxy()
 
-    (website / "author" / author_name_path).mkdir(exist_ok=True, parents=True)
+    (website / "author" / author_name_uri_path).mkdir(exist_ok=True, parents=True)
     apply_template(
-        destination=website / "author" / author_name_path / 'index.html',
+        destination=website / "author" / author_name_uri_path / 'index.html',
         template="author.html",
         game_path=bucket_path,
         bucket=proxy,
@@ -538,7 +538,7 @@ def generate_game(game_path: pathlib.Path, website_path: pathlib.Path) -> Game:
     # Default author page
 
     if "author_link" not in game_toml and "author" in game_toml:
-        author_path = get_author_path(game_toml["author"])
+        author_path = get_author_path(game_toml["author"], True)
         game_toml["author_link"] = base_url+"author/"+author_path+"/index.html" 
 
     # Title.
@@ -767,5 +767,5 @@ def generate(bucket: str) -> None:
 
     print("Website files generated successfully.")
 
-def get_author_path(author: str)-> str:
-    return author.lower().replace(" ", "_")
+def get_author_path(author: str, is_url = False)-> str:
+    return author.lower().replace(" ", "-" if is_url else "_")

--- a/src/pybucketgames/resources/game.toml
+++ b/src/pybucketgames/resources/game.toml
@@ -11,11 +11,11 @@ A new game - but far from the last one.
 
 # Optional author information
 #author="Cool Author"
-#author_link="https://mycoolwebsite.example.com"
+#author_link="https://mycoolwebsite.example.com" # use "" to disable, defaults to a generated author page
 #author_blurb="""Some Markdown text about the author"""
 
-#author_file="coolauthor.toml" # Relative to rebucketgames/authors . Can contains reusable author info
-#author_pic="coolauthor.png" # will look for an "author" img by default, but this can be added to the author_file and reused
+#author_file="coolauthor.toml" # Contains reusable author info. Will look for pybucketgames/authors/[author_name_with_underscores].toml . Deprecated. 
+#author_pic="coolauthor.png" # will look for an "author" img by default, but this can be added to the author_file and reused. Relative to the toml file it's set in
 
 #platforms = "PC, Mac, and Linux"
 

--- a/src/pybucketgames/resources/game.toml
+++ b/src/pybucketgames/resources/game.toml
@@ -14,7 +14,7 @@ A new game - but far from the last one.
 #author_link="https://mycoolwebsite.example.com" # use "" to disable, defaults to a generated author page
 #author_blurb="""Some Markdown text about the author"""
 
-#author_file="coolauthor.toml" # Contains reusable author info. Will look for pybucketgames/authors/[author_name_with_underscores].toml . Deprecated. 
+#author_file="coolauthor.toml" # Contains reusable author info. Will look for pybucketgames/authors/[author_name_with_underscores].toml by default 
 #author_pic="coolauthor.png" # will look for an "author" img by default, but this can be added to the author_file and reused. Relative to the toml file it's set in
 
 #platforms = "PC, Mac, and Linux"

--- a/src/pybucketgames/templates/author.html
+++ b/src/pybucketgames/templates/author.html
@@ -1,0 +1,41 @@
+{% extends "default/bucket.html" %}
+
+{% set base_path = "../../../" %}
+
+{% block head scoped %}
+{{ super() }}
+{% endblock %}
+
+{% block before_content scoped %}
+    <div id="back-button" class="mt-2">
+        <a class="btn p-2" href="../../index.html">Home</a>
+    </div>
+{% endblock %}
+
+{% block before_games scoped %}
+
+{% if page.author_blurb %}
+<div class="content mt-3">
+    <div class="row">
+        <div class="col-md-8">
+            {% if page.author %}
+            <h2>About {{ page.author }}</h2>
+            {% endif %}
+            <p>
+                {{ page.author_blurb | markdown }}
+            </p>
+        </div>
+        {% if page.image_link('author') or page.author_pic %}
+        <div class="col-md">
+            <div id="author-img-contain" class="img-contain">
+                <img id="author-img" class="img-fluid mb-3 thumbnail" src="{{ base_path }}{{ page.image_obj('author').link or page.image_link(page.author_pic) }}" height="{{ page.image_obj('author').height }}" width="{{ page.image_obj('author').width }}" alt="Author's image" loading="lazy">
+            </div>
+        </div>
+        {% endif %}
+    </div>
+</div>
+{% endif %}
+
+{% endblock %}
+
+

--- a/src/pybucketgames/templates/author.html
+++ b/src/pybucketgames/templates/author.html
@@ -9,32 +9,34 @@
 {% endblock %}
 
 {% block bucket_desc scoped %}
-{# Extend this template and comment out/remove the super() to remove the bucket description #}
-{{ super() }}
+{# super() #}
 {% endblock %}
 
 {% block before_games scoped %}
 
-{% if page.author_blurb %}
+{% if page.author and page.author_blurb %}
 <div class="content mt-3">
     <div class="row">
-        <div class="{% if page.image_link('author') or page.author_pic %} col-md-8 {% else %} col {% endif %}">
-            {% if page.author %}
+        {% if page.image_link('author') or page.author_pic %}
+        <div class="col-md-2">
+            <div id="author-img-contain" class="text-center">
+                {% if page.author_pic %}
+                <img id="author-img" class="img-fluid mb-3 thumbnail" src="{{ base_path }}{{ page.image_obj(page.author_pic).link }}" height="{{ page.image_obj(page.author_pic).height }}" width="{{ page.image_obj(page.author_pic).width }}" alt="Author's image" loading="lazy">
+                {% else %}
+                <img id="author-img" class="img-fluid mb-3 thumbnail" src="{{ base_path }}{{ page.image_obj('author').link }}" height="{{ page.image_obj('author').height }}" width="{{ page.image_obj('author').width }}" alt="Author's image" loading="lazy">
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
+        <div class="col-md">
             <h2>About {{ page.author }}</h2>
-            {% endif %}
             <p>
                 {{ page.author_blurb | markdown }}
             </p>
         </div>
-        {% if page.image_link('author') or page.author_pic %}
-        <div class="col-md">
-            <div id="author-img-contain" class="img-contain">
-                <img id="author-img" class="img-fluid mb-3 thumbnail" src="{{ base_path }}{{ page.image_obj('author').link or page.image_link(page.author_pic) }}" height="{{ page.image_obj('author').height }}" width="{{ page.image_obj('author').width }}" alt="Author's image" loading="lazy">
-            </div>
-        </div>
-        {% endif %}
     </div>
 </div>
+
 {% endif %}
 
 {% endblock %}

--- a/src/pybucketgames/templates/author.html
+++ b/src/pybucketgames/templates/author.html
@@ -2,10 +2,6 @@
 
 {% set base_path = "../../../" %}
 
-{% block head scoped %}
-{{ super() }}
-{% endblock %}
-
 {% block before_content scoped %}
     <div id="back-button" class="mt-2">
         <a class="btn p-2" href="../../index.html">Home</a>
@@ -13,6 +9,18 @@
 {% endblock %}
 
 {% block before_games scoped %}
+
+<div class="content mt-3">
+    <div class="row">
+        <div class="col text-center">
+            <h2>Games By {{ page.author }}</h2>
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block after_games scoped %}
 
 {% if page.author_blurb %}
 <div class="content mt-3">

--- a/src/pybucketgames/templates/author.html
+++ b/src/pybucketgames/templates/author.html
@@ -8,24 +8,17 @@
     </div>
 {% endblock %}
 
-{% block before_games scoped %}
-
-<div class="content mt-3">
-    <div class="row">
-        <div class="col text-center">
-            <h2>Games By {{ page.author }}</h2>
-        </div>
-    </div>
-</div>
-
+{% block bucket_desc scoped %}
+{# Extend this template and comment out/remove the super() to remove the bucket description #}
+{{ super() }}
 {% endblock %}
 
-{% block after_games scoped %}
+{% block before_games scoped %}
 
 {% if page.author_blurb %}
 <div class="content mt-3">
     <div class="row">
-        <div class="col-md-8">
+        <div class="{% if page.image_link('author') or page.author_pic %} col-md-8 {% else %} col {% endif %}">
             {% if page.author %}
             <h2>About {{ page.author }}</h2>
             {% endif %}

--- a/src/pybucketgames/templates/bucket.html
+++ b/src/pybucketgames/templates/bucket.html
@@ -1,15 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
-
+{% set base_path = base_path | default("./") %}
 <head>
+    {% block head scoped%}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% if page.image_link('icon') %}
-    <link rel="icon" type="image/x-icon" href="{{ page.image_link('icon') }}">
+    <link rel="icon" type="image/x-icon" href="{{ base_path }}{{ page.image_link('icon') }}">
     {% endif %}
-    <link rel="preload" href="./_static/bootstrap.min.css" as="style" />
-    <link href="./_static/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="preload" href="{{ base_path }}_static/bootstrap.min.css" as="style" />
+    <link href="{{ base_path }}_static/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="{{ base_path }}style.css">
     <style>
         {{ page.css }}
     </style>
@@ -21,14 +22,22 @@
     {% if page.image_link('icon') %}
     <meta property="og:image" content="{{ base_url }}{{ page.image_link('icon') }}" />
     {% endif %}
+    {% endblock %}
+
     {% block end_head scoped%}
     {% endblock %}
 </head>
 
 <body>
 
-    <div class="container" id="bucket-content">
+    {% block before_content scoped %}
+    {% endblock %}
 
+    <div class="container" id="bucket-content">
+        {% block before_bucket_desc scoped %}
+        {% endblock %}
+        
+        {% block bucket_desc scoped %}
         {% if bucket.description %}
         <div class="row mt-3">
             <div class="col">
@@ -40,6 +49,10 @@
             </div>
         </div>
         {% endif %}
+        {% endblock %}
+
+        {% block before_games scoped %}
+        {% endblock %}
 
         <div class="row mt-3">
             {% for game in bucket.games %}
@@ -47,13 +60,13 @@
             <div class="margin-spacer col-md-3 mb-3">
                 <div class="card">
                     {% if game.image_link('cover') %}
-                    <a href="{{ game.directory }}/index.html" class="card-img-top img-contain">
-                        <img src="{{ game.directory }}/{{ game.image_link('cover') }}" alt="Cover image for {{ game.title }}" class="card-img-top img-fluid" height="{{ game.image_obj('cover').height }}" width="{{ game.image_obj('cover').width }}">
+                    <a href="{{ base_path }}{{ game.directory }}/index.html" class="card-img-top img-contain">
+                        <img src="{{ base_path }}{{ game.directory }}/{{ game.image_link('cover') }}" alt="Cover image for {{ game.title }}" class="card-img-top img-fluid" height="{{ game.image_obj('cover').height }}" width="{{ game.image_obj('cover').width }}">
                     </a>
                     {% endif %}
 
                     <div class="card-body">
-                        <h5 class="card-title mb-0"><a href="{{ game.directory }}/index.html">{{ game.title }}</a></h5>
+                        <h5 class="card-title mb-0"><a href="{{ base_path }}{{ game.directory }}/index.html">{{ game.title }}</a></h5>
                         <div class="text-muted">
                             {% if game.author and game.author_link %}
                             By <a class="author-link" href="{{ game.author_link }}">{{ game.author }}</a>
@@ -90,8 +103,8 @@
     </div>
 
     {% block end_body %}
-    <script src="./_static/bootstrap.bundle.min.js"></script>
-    <script src="script.js"></script>
+    <script src="{{ base_path }}_static/bootstrap.bundle.min.js"></script>
+    <script src="{{ base_path }}script.js"></script>
     <script>
         {% autoescape false %}{{ page.js }}{% endautoescape %}
     </script>

--- a/src/pybucketgames/templates/bucket.html
+++ b/src/pybucketgames/templates/bucket.html
@@ -83,6 +83,7 @@
         </div>
         
         {% block after_games scoped %}
+        <div class="row clear-cols-bottom"></div>
         {% endblock %}
 
         {% block bucket_footer_row %}

--- a/src/pybucketgames/templates/bucket.html
+++ b/src/pybucketgames/templates/bucket.html
@@ -82,7 +82,7 @@
             {% endfor %}
         </div>
         
-        {% block after_games %}
+        {% block after_games scoped %}
         {% endblock %}
 
         {% block bucket_footer_row %}

--- a/src/pybucketgames/templates/game.html
+++ b/src/pybucketgames/templates/game.html
@@ -51,9 +51,15 @@
     {% endif %}
     {% endblock %}
 
+    {% block back_button scoped %}
     <div id="back-button" class="mt-2">
-        <a class="btn p-2" href="../index.html">Back</a>
+        <a class="btn p-2" href="../index.html">Home</a>
     </div>
+    <script>
+        document.querySelector('#back-button .btn').href="javascript:history.back()";
+        document.querySelector('#back-button .btn').innerHTML="Back";
+    </script>
+    {% endblock %}
 
     <div class="container mt-2" id="game-content">
 
@@ -149,7 +155,7 @@
         </div>
         {% if game.author_blurb %}
         <div class="row content mb-2">
-            <div class="col-md-8">
+            <div class="{% if game.image_link('author') or game.author_pic %} col-md-8 {% else %} col {% endif %}">
                 {% if game.author %}
                 <h2>About {{ game.author }}</h2>
                 {% endif %}

--- a/src/pybucketgames/templates/game.html
+++ b/src/pybucketgames/templates/game.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-
+{% set base_path = base_path | default("../") %}
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -133,7 +133,7 @@
                 {% block button_links %}
                 {% for btn in game.button_links %}
                 <div>
-                    <a class="btn btn-primary mb-1" href="{{ btn.link }}">
+                    <a class="btn btn-primary mb-3" href="{{ btn.link }}">
                         {% if btn.text %}
                         {{ btn.text }}
                         {% else %}
@@ -153,21 +153,23 @@
             </div>
 
         </div>
-        {% if game.author_blurb %}
+        {% if game.author and game.author_blurb %}
         <div class="row content mb-2">
-            <div class="{% if game.image_link('author') or game.author_pic %} col-md-8 {% else %} col {% endif %}">
-                {% if game.author %}
-                <h2>About {{ game.author }}</h2>
-                {% endif %}
-                <p>{{ game.author_blurb | markdown }}</p>
-            </div>
             {% if game.image_link('author') or game.author_pic %}
             <div class="col-md">
-                <div id="author-img-contain" class="img-contain">
-                    <img id="author-img" class="img-fluid mb-3 thumbnail" src="{{ game.image_obj('author').link or game.image_link(game.author_pic) }}" height="{{ game.image_obj('author').height }}" width="{{ game.image_obj('author').width }}" alt="Author's image" loading="lazy">
+                <div id="author-img-contain" class="img-contain text-center">
+                    {% if game.author_pic %}
+                    <img id="author-img" class="img-fluid mb-3 thumbnail" src="{{ game.image_obj(game.author_pic).link }}" height="{{ game.image_obj(game.author_pic).height }}" width="{{ game.image_obj(game.author_pic).width }}" alt="Author's image" loading="lazy">
+                    {% else %}
+                    <img id="author-img" class="img-fluid mb-3 thumbnail" src="{{ game.image_obj('author').link }}" height="{{ game.image_obj('author').height }}" width="{{ game.image_obj('author').width }}" alt="Author's image" loading="lazy">
+                    {% endif %}
                 </div>
             </div>
             {% endif %}
+            <div class="{% if game.image_link('author') or game.author_pic %} col-md-8 {% else %} col-md {% endif %}">
+                <h2>About <a class="author-link" href="{{base_path}}{{ author_page_link }}" style="color:inherit">{{ game.author }}</a></h2>
+                <p>{{ game.author_blurb | markdown }}</p>
+            </div>
         </div>
         {% endif %}
 

--- a/src/pybucketgames/templates/style.css
+++ b/src/pybucketgames/templates/style.css
@@ -108,6 +108,10 @@ body {
   margin:-3rem
 }
 
+.clear-cols-bottom {
+    margin-top: -1rem;
+}
+
 #bucket-content .row > div > .card {
     height: 100%;
 }


### PR DESCRIPTION
Adds author specific pages that have author's games and bio. 
Accessible at author/[author_name]/index.html
Adds author page as the default author link. Use author_link = "" or set an alternate author_link to disable.
Update the way relative paths for author toml work and deprecate the old paths. `../authors/author.png` should now be `author.png` and author.toml files should be in the expected location based on author's name

- [x] Multilingual/i18n consideration for author file changes

closes #16 